### PR TITLE
feature: custom bucket name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "default_label" {
 
 resource "aws_s3_bucket" "default" {
   count         = var.enabled ? 1 : 0
-  bucket        = module.default_label.id
+  bucket        = var.custom_bucket_name ? var.bucket_name : module.default_label.id
   acl           = var.acl
   region        = var.region
   force_destroy = var.force_destroy

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  source     = "git::https://github.com/pgalchemy/terraform-null-label.git?ref=tags/0.14.1"
   enabled    = var.enabled
   namespace  = var.namespace
   stage      = var.stage

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,15 @@ variable "allow_encrypted_uploads_only" {
   default     = false
   description = "Set to `true` to prevent uploads of unencrypted objects to S3 bucket"
 }
+
+variable "custom_bucket_name" {
+  type = bool
+  default = false
+  description = "Set to `true` to use a custom bucket name"
+}
+
+variable "bucket_name" {
+  type = string
+  default = ""
+  description = "Name of S3 bucket"
+}


### PR DESCRIPTION
Allow ability to set a custom bucket name. Need to set `custom_bucket_name` to true, and then set `bucket_name` to whatever you want the bucket name to be.